### PR TITLE
Removed invalid yml escape character

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3,7 +3,7 @@ en:
     errors:
       messages:
         booking:
-          bookable_must_be_bookable: "cannot book a %{model} as it\'s not bookable"
+          bookable_must_be_bookable: "cannot book a %{model} as it's not bookable"
           booker_must_be_booker: "a %{model} cannot book a resource, because %{model} is not a booker"
         availability:
           amount_gt_capacity: "amount cannot be greater than %{model} capacity"


### PR DESCRIPTION
This was breaking my deployments and it's not necessary to escape the apostrophe anyway because the line is wrapped in double quotes.